### PR TITLE
Fix references to logging symbols defined by system VERBOSE.

### DIFF
--- a/test/util/logger.lisp
+++ b/test/util/logger.lisp
@@ -11,13 +11,13 @@
 		(let ((msg (apply #'format nil format-control format-arguments)))
 		  (cond
 		    ((eq level :info)
-		     (verbose:info who msg))
+		     (org.shirakumo.verbose:info who msg))
 		    ((eq level :debug)
-		     (verbose:debug who msg))
+		     (org.shirakumo.verbose:debug who msg))
 		    ((eq level :warn)
-		     (verbose:warn who msg))
+		     (org.shirakumo.verbose:warn who msg))
 		    ((eq level :error)
-		     (verbose:error who msg))
+		     (org.shirakumo.verbose:error who msg))
 		    ((eq level :trace)
-		     (verbose:trace who msg)))))))))
+		     (org.shirakumo.verbose:trace who msg)))))))))
 


### PR DESCRIPTION
File test/util/logger.lisp is included in system CL-THREADPOOL/TEST, which depends on system VERBOSE.  The file contained references to symbols defined by the code in system VERBOSE but written as "verbose:info" or "verbose:debug". System VERBOSE does not define package VERBOSE but does define a package called ORG.SHIRAKUMO.VERBOSE, so use that package instead.